### PR TITLE
Fixes per changes in mlc-ai/relax

### DIFF
--- a/build.py
+++ b/build.py
@@ -110,7 +110,7 @@ def legalize_and_lift_params(
     )
 
     mod = relax.pipeline.get_pipeline()(mod)
-    mod = relax.transform.RemoveUnusedFunctions(entry_funcs)(mod)
+    mod = relax.transform.DeadCodeElimination(entry_funcs)(mod)
     mod = relax.transform.LiftTransformParams()(mod)
     mod_transform, mod_deploy = utils.split_transform_deploy_mod(
         mod, model_names, entry_funcs
@@ -129,7 +129,7 @@ def build(mod: tvm.IRModule, args: Dict) -> None:
 
     db = ms.database.create(work_dir=args.db_path)
     with args.target, db, tvm.transform.PassContext(opt_level=3):
-        mod_deploy = relax.transform.MetaScheduleApplyDatabase()(mod)
+        mod_deploy = relax.transform.MetaScheduleApplyDatabase(enable_warning=True)(mod)
 
     debug_dump_script(mod_deploy, "mod_build_stage.py", args)
 

--- a/walkthrough.ipynb
+++ b/walkthrough.ipynb
@@ -674,7 +674,7 @@
     ")\n",
     "\n",
     "# Clean up unused parts of the IRModule.\n",
-    "mod = relax.transform.RemoveUnusedFunctions(entry_funcs)(mod)"
+    "mod = relax.transform.DeadCodeElimination(entry_funcs)(mod)"
    ]
   },
   {
@@ -1880,7 +1880,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/web_stable_diffusion/utils.py
+++ b/web_stable_diffusion/utils.py
@@ -57,10 +57,10 @@ def split_transform_deploy_mod(
         else:
             mod_deploy[gv] = func
 
-    mod_transform = relax.transform.RemoveUnusedFunctions(transform_func_names)(
+    mod_transform = relax.transform.DeadCodeElimination(transform_func_names)(
         mod_transform
     )
-    mod_deploy = relax.transform.RemoveUnusedFunctions(mod_deploy_entry_func)(
+    mod_deploy = relax.transform.DeadCodeElimination(mod_deploy_entry_func)(
         mod_deploy
     )
 


### PR DESCRIPTION
This PR fixes the pass name that was changed from RemoveUnusedFunction to DeadCodeElimination. This PR also fixes two workloads in the MetaSchedule database that were corrupted because of one recent update of matmul legalization in mlc/relax.