### PR TITLE
Support importing SD 2.1

### DIFF
--- a/web_stable_diffusion/models/attention.py
+++ b/web_stable_diffusion/models/attention.py
@@ -206,19 +206,26 @@ class SpatialTransformer(nn.Module):
         dropout: float = 0.0,
         num_groups: int = 32,
         context_dim: Optional[int] = None,
+        use_linear_projection=False,
     ):
         super().__init__()
         self.n_heads = n_heads
         self.d_head = d_head
         self.in_channels = in_channels
+        self.use_linear_projection = use_linear_projection
+
         inner_dim = n_heads * d_head
         self.norm = torch.nn.GroupNorm(
             num_groups=num_groups, num_channels=in_channels, eps=1e-6, affine=True
         )
 
-        self.proj_in = nn.Conv2d(
-            in_channels, inner_dim, kernel_size=1, stride=1, padding=0
-        )
+        if use_linear_projection:
+            self.proj_in = nn.Linear(in_channels, inner_dim)
+        else:
+            self.proj_in = nn.Conv2d(
+                in_channels, inner_dim, kernel_size=1, stride=1, padding=0
+            )
+
 
         self.transformer_blocks = nn.ModuleList(
             [
@@ -229,26 +236,38 @@ class SpatialTransformer(nn.Module):
             ]
         )
 
-        self.proj_out = nn.Conv2d(
-            inner_dim, in_channels, kernel_size=1, stride=1, padding=0
-        )
+        if use_linear_projection:
+            self.proj_out = nn.Linear(in_channels, inner_dim)
+        else:
+            self.proj_out = nn.Conv2d(
+                inner_dim, in_channels, kernel_size=1, stride=1, padding=0
+            )
 
     def forward(self, hidden_states, context=None):
         # note: if no context is given, cross-attention defaults to self-attention
-        batch, channel, height, weight = hidden_states.shape
+        batch, channel, height, width = hidden_states.shape
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        hidden_states = self.proj_in(hidden_states)
-        inner_dim = hidden_states.shape[1]
-        hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(
-            batch, height * weight, inner_dim
-        )
+
+        if not self.use_linear_projection:
+            hidden_states = self.proj_in(hidden_states)
+            inner_dim = hidden_states.shape[1]
+            hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(batch, height * width, inner_dim)
+        else:
+            inner_dim = hidden_states.shape[1]
+            hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(batch, height * width, inner_dim)
+            hidden_states = self.proj_in(hidden_states)
+
         for block in self.transformer_blocks:
             hidden_states = block(hidden_states, context=context)
-        hidden_states = hidden_states.reshape(batch, height, weight, inner_dim).permute(
-            0, 3, 1, 2
-        )
-        hidden_states = self.proj_out(hidden_states)
+
+        if not self.use_linear_projection:
+            hidden_states = hidden_states.reshape(batch, height, width, inner_dim).permute(0, 3, 1, 2)
+            hidden_states = self.proj_out(hidden_states)
+        else:
+            hidden_states = self.proj_out(hidden_states)
+            hidden_states = hidden_states.reshape(batch, height, width, inner_dim).permute(0, 3, 1, 2)
+
         return hidden_states + residual
 
 

--- a/web_stable_diffusion/models/unet_blocks.py
+++ b/web_stable_diffusion/models/unet_blocks.py
@@ -19,6 +19,7 @@ def get_down_block(
     resnet_groups=None,
     cross_attention_dim=None,
     downsample_padding=None,
+    use_linear_projection=False,
 ):
     down_block_type = (
         down_block_type[7:]
@@ -54,6 +55,7 @@ def get_down_block(
             downsample_padding=downsample_padding,
             cross_attention_dim=cross_attention_dim,
             attn_num_head_channels=attn_num_head_channels,
+            use_linear_projection=use_linear_projection,
         )
     raise ValueError(f"{down_block_type} does not exist.")
 
@@ -71,6 +73,7 @@ def get_up_block(
     attn_num_head_channels,
     resnet_groups=None,
     cross_attention_dim=None,
+    use_linear_projection=False,
 ):
     up_block_type = (
         up_block_type[7:] if up_block_type.startswith("UNetRes") else up_block_type
@@ -104,6 +107,7 @@ def get_up_block(
             resnet_groups=resnet_groups,
             cross_attention_dim=cross_attention_dim,
             attn_num_head_channels=attn_num_head_channels,
+            use_linear_projection=use_linear_projection,
         )
     elif up_block_type == "UpDecoderBlock2D":
         return UpDecoderBlock2D(
@@ -344,6 +348,7 @@ class CrossAttnDownBlock2D(nn.Module):
         output_scale_factor=1.0,
         downsample_padding=1,
         add_downsample=True,
+        use_linear_projection=False,
     ):
         super().__init__()
         resnets = []
@@ -376,6 +381,7 @@ class CrossAttnDownBlock2D(nn.Module):
                     depth=1,
                     context_dim=cross_attention_dim,
                     num_groups=resnet_groups,
+                    use_linear_projection=use_linear_projection,
                 )
             )
         self.attentions = nn.ModuleList(attentions)
@@ -429,6 +435,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
         attention_type="default",
         output_scale_factor=1.0,
         cross_attention_dim=1280,
+        use_linear_projection=False,
         **kwargs,
     ):
         super().__init__()
@@ -465,6 +472,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
                     depth=1,
                     context_dim=cross_attention_dim,
                     num_groups=resnet_groups,
+                    use_linear_projection=use_linear_projection,
                 )
             )
             resnets.append(
@@ -578,6 +586,7 @@ class CrossAttnUpBlock2D(nn.Module):
         attention_type="default",
         output_scale_factor=1.0,
         downsample_padding=1,
+        use_linear_projection=False,
         add_upsample=True,
     ):
         super().__init__()
@@ -613,6 +622,7 @@ class CrossAttnUpBlock2D(nn.Module):
                     depth=1,
                     context_dim=cross_attention_dim,
                     num_groups=resnet_groups,
+                    use_linear_projection=use_linear_projection,
                 )
             )
         self.attentions = nn.ModuleList(attentions)

--- a/web_stable_diffusion/utils.py
+++ b/web_stable_diffusion/utils.py
@@ -14,9 +14,19 @@ def detect_available_torch_device() -> str:
     raise ValueError("At least one GPU backend is expected to be enabled")
 
 
-def get_unet(pipe, device_str: str):
+def get_unet(
+    pipe,
+    device_str: str,
+    cross_attention_dim=768,
+    attention_head_dim=8,
+    use_linear_projection=False,
+):
     model = TVMUNet2DConditionModel(
-        sample_size=64, cross_attention_dim=768, device=device_str
+        sample_size=64,
+        cross_attention_dim=cross_attention_dim,
+        attention_head_dim=attention_head_dim,
+        use_linear_projection=use_linear_projection,
+        device=device_str,
     )
     pt_model_dict = pipe.unet.state_dict()
     model_dict = {}
@@ -60,9 +70,7 @@ def split_transform_deploy_mod(
     mod_transform = relax.transform.DeadCodeElimination(transform_func_names)(
         mod_transform
     )
-    mod_deploy = relax.transform.DeadCodeElimination(mod_deploy_entry_func)(
-        mod_deploy
-    )
+    mod_deploy = relax.transform.DeadCodeElimination(mod_deploy_entry_func)(mod_deploy)
 
     return mod_transform, mod_deploy
 


### PR DESCRIPTION
Updated the SD UNet definition to support both v1.5 and v2.1. 

Tested with

```
import tvm
from diffusers import StableDiffusionPipeline, EulerDiscreteScheduler
import web_stable_diffusion.trace as trace
from tvm.relax.frontend import detach_params


def serialize(mod, params, prefix):
    f = mod[prefix]
    params_list = params[prefix]
    param_names = [p.name_hint for p in f.params]

    params_dict = dict(zip(param_names[-len(params_list):], params_list))

    with open("{}.json".format(prefix), "w") as fo:
        fo.write(tvm.ir.save_json(mod))

    tvm.runtime.save_param_dict_to_file(params_dict, "{}.params".format(prefix))


# pipe = StableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5")

model_id = "stabilityai/stable-diffusion-2-1-base"
scheduler = EulerDiscreteScheduler.from_pretrained(model_id, subfolder="scheduler")
pipe = StableDiffusionPipeline.from_pretrained(model_id, scheduler=scheduler)

unet, params_unet = detach_params(trace.unet_latents_to_noise_pred(pipe, "mps"))

serialize(unet, params_unet, "unet")
```

@spectrometerHBH @MasterJH5574 @tqchen 